### PR TITLE
Fixed ViewResolverTest

### DIFF
--- a/3-0-spring-framework/3-0-2-view-resolver/src/test/java/com/bobocode/ViewResolverTest.java
+++ b/3-0-spring-framework/3-0-2-view-resolver/src/test/java/com/bobocode/ViewResolverTest.java
@@ -72,7 +72,7 @@ public class ViewResolverTest {
     @Order(6)
     @DisplayName("Config class overrides configureViewResolvers method")
     void isConfigurationClassContainsViewResolverMethod() {
-        Method configureViewResolvers = ResolverConfig.class.getMethod("configureViewResolvers", ViewResolverRegistry.class);
+        Method configureViewResolvers = ResolverConfig.class.getDeclaredMethod("configureViewResolvers", ViewResolverRegistry.class);
         assertNotNull(configureViewResolvers);
     }
 


### PR DESCRIPTION
Fixed isConfigurationClassContainsViewResolverMethod() in ViewResolverTest. Changed method of getting declared methods in 3-0-2-view-resolver exercise to:
` Method configureViewResolvers=ResolverConfig.class.getDeclaredMethod("configureViewResolvers",ViewResolverRegistry.class);
`